### PR TITLE
Fixed risk weight mapping for FX Vega

### DIFF
--- a/src/margin_risk_class.py
+++ b/src/margin_risk_class.py
@@ -431,17 +431,13 @@ class MarginByRiskClass:
                     pair_list = [currency_pair, currency_pair[3:]+currency_pair[:3]]    
                     crif_fx   = self.crif[(self.crif['RiskType']  == risk_class) & (self.crif['Qualifier'].isin(pair_list))]
                     
-                    is_given_currency = (currency_pair[:3] in wnc.high_vol_currency_group or currency_pair[3:] in wnc.high_vol_currency_group) 
-                    is_calc_currency  = self.calculation_currency in wnc.high_vol_currency_group
+                    is_currency1 = currency_pair[:3] in wnc.high_vol_currency_group
+                    is_currency2 = currency_pair[3:] in wnc.high_vol_currency_group
 
-                    if (is_given_currency==True) and (is_calc_currency==True):
-                        RW  = wnc.fx_rw['High']['High']
-                    elif (is_given_currency==True) and (is_calc_currency==False):
-                        RW  = wnc.fx_rw['High']['Regular']
-                    elif (is_given_currency==False) and (is_calc_currency==True):
-                        RW  = wnc.fx_rw['Regular']['High']                    
-                    elif (is_given_currency==False) and (is_calc_currency==False):
-                        RW  = wnc.fx_rw['Regular']['Regular']
+                    fx_vol_group1 = 'High' if is_currency1 else 'Regular'
+                    fx_vol_group2 = 'High' if is_currency2 else 'Regular'
+
+                    RW = wnc.fx_rw[fx_vol_group2][fx_vol_group1]
 
                     sigma = RW * sqrt(365/14)/norm.ppf(0.99)
 


### PR DESCRIPTION
As per 10 (b) [page 5]: use first currency and second currency to determine fx vega.  Do not use calculation currency.
This fix enables two additional unit tests to pass [C342, C359].