### PR TITLE
Update weights_corr2_5.py

### DIFF
--- a/src/weights_corr2_5.py
+++ b/src/weights_corr2_5.py
@@ -446,7 +446,7 @@ ir_vega_CT = {
 # p.27, 83: Vega Concentration Thresholds for Credit Spread Risk
 credit_vega_CT = {
     "Qualifying"     : 260, 
-    "Non-Qualifying" : 1455,
+    "Non-Qualifying" : 145,
 }
 
 # p.28, 84: Vega Concentration Thresholds for Equity Risk


### PR DESCRIPTION
typo in CreditNonQ vega concentration threshold.  See page 27: section 83.  Correct value should be USD 145 mm.  This fixes test C391.